### PR TITLE
Add basic offline payment handlers

### DIFF
--- a/packages/core/src/api/resolvers/admin/order.resolver.ts
+++ b/packages/core/src/api/resolvers/admin/order.resolver.ts
@@ -38,6 +38,7 @@ import { FulfillmentState } from '../../../service/helpers/fulfillment-state-mac
 import { OrderState } from '../../../service/helpers/order-state-machine/order-state';
 import { PaymentState } from '../../../service/helpers/payment-state-machine/payment-state';
 import { OrderService } from '../../../service/services/order.service';
+import { BankTransferService } from '../../../service';
 import { RequestContext } from '../../common/request-context';
 import { Allow } from '../../decorators/allow.decorator';
 import { RelationPaths, Relations } from '../../decorators/relations.decorator';
@@ -49,6 +50,7 @@ export class OrderResolver {
     constructor(
         private orderService: OrderService,
         private connection: TransactionalConnection,
+        private bankTransferService: BankTransferService,
     ) {}
 
     @Query()
@@ -218,5 +220,16 @@ export class OrderResolver {
         @Args() args: MutationAddManualPaymentToOrderArgs,
     ) {
         return this.orderService.addManualPaymentToOrder(ctx, args.input);
+    }
+
+    @Transaction()
+    @Mutation()
+    @Allow(Permission.UpdateOrder)
+    async verifyBankTransfer(
+        @Ctx() ctx: RequestContext,
+        @Args('orderId') orderId: ID,
+        @Args('verified') verified: boolean,
+    ) {
+        return this.bankTransferService.verify(ctx, orderId, verified);
     }
 }

--- a/packages/core/src/api/resolvers/shop/shop-order.resolver.ts
+++ b/packages/core/src/api/resolvers/shop/shop-order.resolver.ts
@@ -40,6 +40,7 @@ import { ACTIVE_ORDER_INPUT_FIELD_NAME, ConfigService, LogLevel } from '../../..
 import { Country } from '../../../entity';
 import { Order } from '../../../entity/order/order.entity';
 import { ActiveOrderService, CountryService } from '../../../service';
+import { BankTransferService } from '../../../service';
 import { OrderState } from '../../../service/helpers/order-state-machine/order-state';
 import { CustomerService } from '../../../service/services/customer.service';
 import { OrderService } from '../../../service/services/order.service';
@@ -61,6 +62,7 @@ export class ShopOrderResolver {
         private countryService: CountryService,
         private activeOrderService: ActiveOrderService,
         private configService: ConfigService,
+        private bankTransferService: BankTransferService,
     ) {}
 
     @Query()
@@ -467,6 +469,17 @@ export class ShopOrderResolver {
             }
         }
         return new NoActiveOrderError();
+    }
+
+    @Transaction()
+    @Mutation()
+    @Allow(Permission.Owner)
+    async uploadBankTransferProof(
+        @Ctx() ctx: RequestContext,
+        @Args('orderId') orderId: ID,
+        @Args('proof') proof: string,
+    ) {
+        return this.orderService.bankTransferService.uploadProof(ctx, orderId, proof);
     }
 
     @Transaction()

--- a/packages/core/src/api/schema/admin-api/order.api.graphql
+++ b/packages/core/src/api/schema/admin-api/order.api.graphql
@@ -38,6 +38,8 @@ type Mutation {
     Payment.
     """
     addManualPaymentToOrder(input: ManualPaymentInput!): AddManualPaymentToOrderResult!
+    "Verify or reject a bank transfer"
+    verifyBankTransfer(orderId: ID!, verified: Boolean!): BankTransferVerification!
     "Creates a draft Order"
     createDraftOrder: Order!
     "Deletes a draft Order"

--- a/packages/core/src/api/schema/common/bank-transfer-verification.type.graphql
+++ b/packages/core/src/api/schema/common/bank-transfer-verification.type.graphql
@@ -1,0 +1,8 @@
+type BankTransferVerification implements Node {
+    id: ID!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    uploadedProofUrl: String
+    verified: Boolean!
+    expiresAt: DateTime!
+}

--- a/packages/core/src/api/schema/common/order.type.graphql
+++ b/packages/core/src/api/schema/common/order.type.graphql
@@ -63,6 +63,7 @@ type Order implements Node {
     A summary of the taxes being applied to this Order
     """
     taxSummary: [OrderTaxSummary!]!
+    bankTransferVerification: BankTransferVerification
     history(options: HistoryEntryListOptions): HistoryEntryList!
 }
 

--- a/packages/core/src/api/schema/shop-api/shop.api.graphql
+++ b/packages/core/src/api/schema/shop-api/shop.api.graphql
@@ -101,6 +101,8 @@ type Mutation {
     setOrderShippingMethod(shippingMethodId: [ID!]!): SetOrderShippingMethodResult!
     "Add a Payment to the Order"
     addPaymentToOrder(input: PaymentInput!): AddPaymentToOrderResult!
+    "Upload proof of bank transfer payment"
+    uploadBankTransferProof(orderId: ID!, proof: String!): BankTransferVerification!
     "Set the Customer for the Order. Required only if the Customer is not currently logged in"
     setCustomerForOrder(input: CreateCustomerInput!): SetCustomerForOrderResult!
     """

--- a/packages/core/src/config/payment/bank-transfer-payment-method-handler.ts
+++ b/packages/core/src/config/payment/bank-transfer-payment-method-handler.ts
@@ -1,0 +1,26 @@
+import { LanguageCode } from '@vendure/common/lib/generated-types';
+import { CreatePaymentResult, PaymentMethodHandler, SettlePaymentResult } from './payment-method-handler';
+import { BankTransferService } from '../../service/services/bank-transfer.service';
+
+let bankTransferService: BankTransferService;
+
+export const bankTransferPaymentHandler = new PaymentMethodHandler({
+    code: 'bank-transfer',
+    description: [{ languageCode: LanguageCode.en, value: 'Bank Transfer' }],
+    args: {},
+    init(injector) {
+        bankTransferService = injector.get(BankTransferService);
+    },
+    createPayment: async (ctx, order, amount): Promise<CreatePaymentResult> => {
+        if (!bankTransferService) {
+            throw new Error('BankTransferService not initialized');
+        }
+        await bankTransferService.startVerification(ctx, order);
+        return {
+            amount,
+            state: 'Pending' as const,
+            transactionId: order.code + '-bank-transfer',
+        };
+    },
+    settlePayment: async (): Promise<SettlePaymentResult> => ({ success: true }),
+});

--- a/packages/core/src/config/payment/cod-payment-method-handler.ts
+++ b/packages/core/src/config/payment/cod-payment-method-handler.ts
@@ -1,0 +1,16 @@
+import { LanguageCode } from '@vendure/common/lib/generated-types';
+import { CreatePaymentResult, PaymentMethodHandler, SettlePaymentResult } from './payment-method-handler';
+
+export const codPaymentHandler = new PaymentMethodHandler({
+    code: 'cash-on-delivery',
+    description: [{ languageCode: LanguageCode.en, value: 'Cash on Delivery' }],
+    args: {},
+    createPayment: async (ctx, order, amount): Promise<CreatePaymentResult> => {
+        return {
+            amount,
+            state: 'Settled' as const,
+            transactionId: order.code + '-cod',
+        };
+    },
+    settlePayment: async (): Promise<SettlePaymentResult> => ({ success: true }),
+});

--- a/packages/core/src/entity/bank-transfer-verification/bank-transfer-verification.entity.ts
+++ b/packages/core/src/entity/bank-transfer-verification/bank-transfer-verification.entity.ts
@@ -1,0 +1,25 @@
+import { DeepPartial } from '@vendure/common/lib/shared-types';
+import { Column, Entity, Index, ManyToOne } from 'typeorm';
+
+import { VendureEntity } from '../base/base.entity';
+import { Order } from '../order/order.entity';
+
+@Entity()
+export class BankTransferVerification extends VendureEntity {
+    constructor(input?: DeepPartial<BankTransferVerification>) {
+        super(input);
+    }
+
+    @Index()
+    @ManyToOne(() => Order, order => order.bankTransferVerification, { onDelete: 'CASCADE' })
+    order: Order;
+
+    @Column({ nullable: true })
+    uploadedProofUrl?: string;
+
+    @Column({ default: false })
+    verified: boolean;
+
+    @Column()
+    expiresAt: Date;
+}

--- a/packages/core/src/entity/entities.ts
+++ b/packages/core/src/entity/entities.ts
@@ -64,6 +64,7 @@ import { Sale } from './stock-movement/sale.entity';
 import { StockAdjustment } from './stock-movement/stock-adjustment.entity';
 import { StockMovement } from './stock-movement/stock-movement.entity';
 import { Surcharge } from './surcharge/surcharge.entity';
+import { BankTransferVerification } from './bank-transfer-verification/bank-transfer-verification.entity';
 import { Tag } from './tag/tag.entity';
 import { TaxCategory } from './tax-category/tax-category.entity';
 import { TaxRate } from './tax-rate/tax-rate.entity';
@@ -139,6 +140,7 @@ export const coreEntitiesMap = {
     StockLocation,
     StockMovement,
     Surcharge,
+    BankTransferVerification,
     Tag,
     TaxCategory,
     TaxRate,

--- a/packages/core/src/entity/index.ts
+++ b/packages/core/src/entity/index.ts
@@ -57,6 +57,7 @@ export * from './stock-movement/sale.entity';
 export * from './stock-movement/stock-adjustment.entity';
 export * from './stock-movement/stock-movement.entity';
 export * from './surcharge/surcharge.entity';
+export * from './bank-transfer-verification/bank-transfer-verification.entity';
 export * from './tag/tag.entity';
 export * from './tax-category/tax-category.entity';
 export * from './tax-rate/tax-rate.entity';

--- a/packages/core/src/entity/order/order.entity.ts
+++ b/packages/core/src/entity/order/order.entity.ts
@@ -8,7 +8,7 @@ import {
 } from '@vendure/common/lib/generated-types';
 import { DeepPartial, ID } from '@vendure/common/lib/shared-types';
 import { summate } from '@vendure/common/lib/shared-utils';
-import { Column, Entity, Index, JoinTable, ManyToMany, ManyToOne, OneToMany } from 'typeorm';
+import { Column, Entity, Index, JoinTable, ManyToMany, ManyToOne, OneToMany, OneToOne } from 'typeorm';
 
 import { Calculated } from '../../common/calculated-decorator';
 import { InternalServerError } from '../../common/error/errors';
@@ -28,6 +28,7 @@ import { Payment } from '../payment/payment.entity';
 import { Promotion } from '../promotion/promotion.entity';
 import { ShippingLine } from '../shipping-line/shipping-line.entity';
 import { Surcharge } from '../surcharge/surcharge.entity';
+import { BankTransferVerification } from '../bank-transfer-verification/bank-transfer-verification.entity';
 
 /**
  * @description
@@ -152,6 +153,9 @@ export class Order extends VendureEntity implements ChannelAware, HasCustomField
 
     @OneToMany(type => OrderModification, modification => modification.order)
     modifications: OrderModification[];
+
+    @OneToOne(() => BankTransferVerification, verification => verification.order)
+    bankTransferVerification?: BankTransferVerification;
 
     /**
      * @description

--- a/packages/core/src/service/index.ts
+++ b/packages/core/src/service/index.ts
@@ -43,6 +43,7 @@ export * from './services/order-testing.service';
 export * from './services/order.service';
 export * from './services/payment-method.service';
 export * from './services/payment.service';
+export * from './services/bank-transfer.service';
 export * from './services/product-option-group.service';
 export * from './services/product-option.service';
 export * from './services/product-variant.service';

--- a/packages/core/src/service/service.module.ts
+++ b/packages/core/src/service/service.module.ts
@@ -50,6 +50,7 @@ import { OrderTestingService } from './services/order-testing.service';
 import { OrderService } from './services/order.service';
 import { PaymentMethodService } from './services/payment-method.service';
 import { PaymentService } from './services/payment.service';
+import { BankTransferService } from './services/bank-transfer.service';
 import { ProductOptionGroupService } from './services/product-option-group.service';
 import { ProductOptionService } from './services/product-option.service';
 import { ProductVariantService } from './services/product-variant.service';
@@ -86,6 +87,7 @@ const services = [
     OrderService,
     OrderTestingService,
     PaymentService,
+    BankTransferService,
     PaymentMethodService,
     ProductOptionGroupService,
     ProductOptionService,

--- a/packages/core/src/service/services/bank-transfer.service.ts
+++ b/packages/core/src/service/services/bank-transfer.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { ID } from '@vendure/common/lib/shared-types';
+
+import { RequestContext } from '../../api/common/request-context';
+import { JobQueue } from '../../job-queue/job-queue';
+import { JobQueueService } from '../../job-queue/job-queue.service';
+import { TransactionalConnection } from '../../connection/transactional-connection';
+import { Order } from '../../entity/order/order.entity';
+import { BankTransferVerification } from '../../entity/bank-transfer-verification/bank-transfer-verification.entity';
+import { OrderService } from './order.service';
+import { RequestContextService } from '../helpers/request-context/request-context.service';
+
+@Injectable()
+export class BankTransferService implements OnModuleInit {
+    private expirationQueue: JobQueue<{ orderId: ID }>;
+
+    constructor(
+        private connection: TransactionalConnection,
+        private jobQueueService: JobQueueService,
+        private orderService: OrderService,
+        private requestContextService: RequestContextService,
+    ) {}
+
+    async onModuleInit() {
+        this.expirationQueue = await this.jobQueueService.createQueue({
+            name: 'bank-transfer-expiration',
+            process: async job => {
+                const ctx = await this.requestContextService.create({ apiType: 'admin' });
+                const verification = await this.connection.getRepository(ctx, BankTransferVerification).findOne({
+                    where: { order: { id: job.data.orderId } },
+                    relations: ['order', 'order.payments'],
+                });
+                if (verification && !verification.verified) {
+                    await this.orderService.cancelOrder(ctx, { orderId: job.data.orderId });
+                }
+                return {};
+            },
+        });
+    }
+
+    async startVerification(ctx: RequestContext, order: Order) {
+        const expiresAt = new Date(Date.now() + 48 * 3600 * 1000);
+        const verification = await this.connection.getRepository(ctx, BankTransferVerification).save(
+            new BankTransferVerification({ order, verified: false, expiresAt }),
+        );
+        await this.expirationQueue.add({ orderId: order.id }, { runAt: expiresAt });
+        return verification;
+    }
+
+    async uploadProof(ctx: RequestContext, orderId: ID, proofUrl: string) {
+        const verification = await this.connection.getRepository(ctx, BankTransferVerification).findOne({
+            where: { order: { id: orderId } },
+        });
+        if (!verification) {
+            throw new Error('Verification not found');
+        }
+        verification.uploadedProofUrl = proofUrl;
+        return this.connection.getRepository(ctx, BankTransferVerification).save(verification);
+    }
+
+    async verify(ctx: RequestContext, orderId: ID, verified: boolean) {
+        const verification = await this.connection.getRepository(ctx, BankTransferVerification).findOne({
+            where: { order: { id: orderId } },
+            relations: ['order', 'order.payments'],
+        });
+        if (!verification) {
+            throw new Error('Verification not found');
+        }
+        verification.verified = verified;
+        await this.connection.getRepository(ctx, BankTransferVerification).save(verification);
+        const payment = verification.order.payments[0];
+        if (payment) {
+            const state = verified ? 'Settled' : 'Cancelled';
+            await this.orderService.transitionPaymentToState(ctx, payment.id, state as any);
+        }
+        return verification;
+    }
+}


### PR DESCRIPTION
## Summary
- implement COD and bank transfer PaymentMethodHandlers
- add BankTransferVerification entity and service with expiration job
- expose mutations for bank transfer proof upload and admin verification

## Testing
- `npm run codegen` *(fails: Cannot find module '@graphql-codegen/plugin-helpers')*
- `npx lerna run --scope @vendure/core test` *(fails: needs lerna installation)*

------
https://chatgpt.com/codex/tasks/task_e_683f4e35c4108328be2a11ecb1a090c0